### PR TITLE
Updated kronos-step to version 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "chokidar": "1.1.0",
-    "kronos-step": "1.1.0"
+    "kronos-step": "1.2.1"
   }
 }


### PR DESCRIPTION
:rocket:

kronos-step just published version 1.2.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 6 commits (ahead by 6, behind by 0).

- [13a5339](https://github.com/Kronos-Integration/kronos-step/commit/13a533949d540c9549787b4ad553e4ca6aa48042): fix: Message creation was faulty. The parameters given where not correctly used
- [1e93aba](https://github.com/Kronos-Integration/kronos-step/commit/1e93aba577383a7c14191087f50f1d5cea0da931): feat: Fix the endpoint export in index.js and also proof if an endpoint is already connected
- [e6afa13](https://github.com/Kronos-Integration/kronos-step/commit/e6afa1350e2f6b32905413e1f04a928fcf85918b): Update documentation
- [39b5d26](https://github.com/Kronos-Integration/kronos-step/commit/39b5d266a37480a0ec629aed40aee6cf6fde1627): Update documentation and unit tests
- [b24bc4f](https://github.com/Kronos-Integration/kronos-step/commit/b24bc4f0eb23b1362cf0aba5dea66c773369dad2): doc: Update documentation structure
- [b47fe13](https://github.com/Kronos-Integration/kronos-step/commit/b47fe1327417c126ca737054ba0ba47d3d02a61a): removed unneeded file

See the [full diff](https://github.com/Kronos-Integration/kronos-step/compare/c71899943c4e5a5a5f0ac2a2a73ac463b1a51ebf...13a533949d540c9549787b4ad553e4ca6aa48042).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>